### PR TITLE
Add local.properties to .gitignore

### DIFF
--- a/LibreTasks/.gitignore
+++ b/LibreTasks/.gitignore
@@ -1,2 +1,3 @@
 /gen/
 /bin/
+local.properties


### PR DESCRIPTION
local.properties is (as the name suggests) a local file which should be committed to git, as it contains machine-specific configuration.