### PR TITLE
Fix links to nonexistent wiki

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ LibreTasks automates your Android device by triggering actions based on configur
 For example, you may:
 * pause your media when your charger is disconnected, or 
 * turn off wifi at a certain time of day.
-* [And more!](../../wiki/User-Case-Collection)
+* [And more!](https://code.google.com/archive/p/omnidroid/wikis)
 
 LibreTasks is a fork of [Omnidroid](http://code.google.com/p/omnidroid "Omnidroid") with new features.
 
@@ -15,7 +15,7 @@ LibreTasks is a fork of [Omnidroid](http://code.google.com/p/omnidroid "Omnidroi
 
 Download and install from [F-Droid](https://f-droid.org/ "F-Droid".)
 
-For more help, visit the [wiki](../../wiki/)
+For more help, visit the [Omnidroid wiki](https://code.google.com/archive/p/omnidroid/wikis).
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ LibreTasks automates your Android device by triggering actions based on configur
 For example, you may:
 * pause your media when your charger is disconnected, or 
 * turn off wifi at a certain time of day.
-* [And more!](https://code.google.com/archive/p/omnidroid/wikis)
+* [And more!](https://code.google.com/archive/p/omnidroid/wikis/UserCaseCollection.wiki)
 
 LibreTasks is a fork of [Omnidroid](http://code.google.com/p/omnidroid "Omnidroid") with new features.
 


### PR DESCRIPTION
There is no wiki on the GitHub repo.  Use the Omnidroid wiki instead.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/biotinker/libretasks/236)
<!-- Reviewable:end -->
